### PR TITLE
Add support for partition sets defined by nested node properties

### DIFF
--- a/src/sets.js
+++ b/src/sets.js
@@ -27,12 +27,16 @@ function contains(list, value) {
   return list.indexOf(value) !== -1;
 };
 
+function leaf(element, path) {
+  return path.split('.').reduce((value, property) => value[property], element)
+};
+
 function partitionSet(elements, definition) {
   var partitionSets = {};
 
   // Split the elements into sets based on their partition property.
   elements.forEach(function(element) {
-    var partitionValue = element[definition.partition];
+    var partitionValue = leaf(element, definition.partition);
     if(definition.partition === 'parent' && partitionValue) {
       partitionValue = partitionValue._id; 
     }


### PR DESCRIPTION
Partition sets can currently be defined based on the values of a node property. This change adds support for partition sets defined by nested properties. For example, if we wanted to create a partition based "wand.core":

```json
{
 "id": 1,
 "name": "Harry Potter",
 "height": "5.8",
 "house": "Gryffindor",
 "wand": {
    "core": "phoenix feather",
    "wood": "holly",
    "length": 11
 }
}
```

I understand this would not be an issue if the data on the node was tidy. However, this change adds support for when it's sadly not the case. 

I'm definitely not sure if this is the right approach to the problem, but I'm happy to discuss 
the topic 😀 